### PR TITLE
Fix: can run tests when test-runner is provided on a path with spaces

### DIFF
--- a/src/main/java/eu/stamp_project/testrunner/EntryPoint.java
+++ b/src/main/java/eu/stamp_project/testrunner/EntryPoint.java
@@ -214,7 +214,7 @@ public class EntryPoint {
             throws TimeoutException {
         final String javaCommand = String.join(ConstantsHelper.WHITE_SPACE,
                 new String[]{getJavaCommand(),
-                        classpath + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_RUNNER_CLASSES,
+                        (classpath + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_RUNNER_CLASSES).replaceAll(" ", "%20"),
                         EntryPoint.jUnit5Mode ? EntryPoint.JUNIT5_TEST_RUNNER_QUALIFIED_NAME
                                 : EntryPoint.JUNIT4_TEST_RUNNER_QUALIFIED_NAME,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun,
@@ -293,11 +293,11 @@ public class EntryPoint {
                                        String[] fullQualifiedNameOfTestClasses, String[] methodNames) throws TimeoutException {
         final String javaCommand = String.join(ConstantsHelper.WHITE_SPACE,
                 new String[]{getJavaCommand(),
-                        classpath + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_RUNNER_CLASSES
-                                + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_JACOCO_DEPENDENCIES,
+                        (classpath + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_RUNNER_CLASSES
+                                + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_JACOCO_DEPENDENCIES).replaceAll(" ", "%20"),
                         EntryPoint.jUnit5Mode ? EntryPoint.JUNIT5_JACOCO_RUNNER_QUALIFIED_NAME : EntryPoint.JUNIT4_JACOCO_RUNNER_QUALIFIED_NAME,
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject,
-                        targetProjectClasses, ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun,
+                        (targetProjectClasses).replaceAll(" ", "%20"), ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun,
                         String.join(ConstantsHelper.PATH_SEPARATOR, fullQualifiedNameOfTestClasses),
                         methodNames.length == 0 ? "" :
                                 (ParserOptions.FLAG_testMethodNamesToRun + ConstantsHelper.WHITE_SPACE +
@@ -379,11 +379,11 @@ public class EntryPoint {
         final String javaCommand = String.join(ConstantsHelper.WHITE_SPACE,
                 new String[]{
                         getJavaCommand(),
-                        classpath + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_RUNNER_CLASSES
-                                + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_JACOCO_DEPENDENCIES,
+                        (classpath + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_RUNNER_CLASSES
+                                + ConstantsHelper.PATH_SEPARATOR + ABSOLUTE_PATH_TO_JACOCO_DEPENDENCIES).replaceAll(" ", "%20"),
                         EntryPoint.jUnit5Mode ? EntryPoint.JUNIT5_JACOCO_RUNNER_PER_TEST_QUALIFIED_NAME : EntryPoint.JUNIT4_JACOCO_RUNNER_PER_TEST_QUALIFIED_NAME,
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject,
-                        targetProjectClasses, ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun,
+                        (targetProjectClasses).replaceAll(" ", "%20"), ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun,
                         String.join(ConstantsHelper.PATH_SEPARATOR, fullQualifiedNameOfTestClasses),
                         methodNames.length == 0 ? "" : ParserOptions.FLAG_testMethodNamesToRun + ConstantsHelper.WHITE_SPACE +
                                 String.join(ConstantsHelper.PATH_SEPARATOR, methodNames),

--- a/src/main/java/eu/stamp_project/testrunner/EntryPoint.java
+++ b/src/main/java/eu/stamp_project/testrunner/EntryPoint.java
@@ -452,8 +452,11 @@ public class EntryPoint {
     }
 
     private static void runGivenCommandLine(String commandLine) throws TimeoutException {
+        List<String> command = Arrays.asList(commandLine.split(" "));
+        command = command.stream().map(s -> s.replaceAll("%20", " ")).collect(Collectors.toList());
+
         if (EntryPoint.verbose) {
-            LOGGER.info("Run: {}", commandLine);
+            LOGGER.info("Run: {}", command);
         }
         if (workingDirectory != null && !workingDirectory.exists()) {
             LOGGER.warn(
@@ -464,7 +467,7 @@ public class EntryPoint {
         }
         Process process = null;
         try {
-            ProcessBuilder pb = new ProcessBuilder().command(Arrays.asList(commandLine.split(" ")));
+            ProcessBuilder pb = new ProcessBuilder().command(command);
             if (workingDirectory != null) {
                 pb.directory(workingDirectory);
             }


### PR DESCRIPTION
Hey 🙂

This is a small fix to escape spaces correctly on the path to the test-runner.jar.
For example in an IntellJ Plugin installed on Mac (in ".../Application Support") 😄

Unfortunately this can only be tested manually:
Move the repository to a local path that has spaces in it (e.g. rename the folder to `test- runner`) and execute the unit tests.