### PR TITLE
Feat: add option to set detail of coverage information + method level instruction coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Spoon files
+spooned/
+
 # Config files
 .idea/
 test-runner.iml

--- a/src/main/java/eu/stamp_project/testrunner/EntryPoint.java
+++ b/src/main/java/eu/stamp_project/testrunner/EntryPoint.java
@@ -63,6 +63,7 @@ import java.util.stream.Stream;
  * This class has options accessible from the outside:
  * </p>
  * <ul>
+ * <li>jUnit5Mode: switches from JUnit 4 to the JUnit 5 test runner</li>
  * <li>verbose: boolean to enable traces to track the progress</li>
  * <li>timeoutInMs: integer timeout time in milliseconds for the whole requested
  * process.</li>
@@ -75,6 +76,8 @@ import java.util.stream.Stream;
  * stream</li>
  * <li>persistence: if enable, keeps the configuration between runs, else reset
  * it</li>
+ * <li>blackList: allows to blacklist specific test methods of a test class/li>
+ * <li>coverageDetail: the level of detail in which coverage should be reported</li>
  * </ul>
  */
 public class EntryPoint {
@@ -139,6 +142,12 @@ public class EntryPoint {
      */
     public static List<String> blackList = new ArrayList<>();
 
+    /**
+     * Allows to set the level of detail at which coverage information should be reported.
+     * see {@link ParserOptions.CoverageTransformerDetail}
+     */
+    public static ParserOptions.CoverageTransformerDetail coverageDetail =
+            ParserOptions.CoverageTransformerDetail.SUMMARIZED;
 
     // PIT OPTIONS
 
@@ -305,6 +314,9 @@ public class EntryPoint {
                         EntryPoint.blackList.isEmpty() ? "" :
                                 (ParserOptions.FLAG_blackList + ConstantsHelper.WHITE_SPACE
                                         + String.join(ConstantsHelper.PATH_SEPARATOR, EntryPoint.blackList)),
+                        EntryPoint.coverageDetail == ParserOptions.CoverageTransformerDetail.SUMMARIZED ? "" :
+                                (ParserOptions.FLAG_coverage_detail + ConstantsHelper.WHITE_SPACE
+                                        + EntryPoint.coverageDetail.name()),
                 });
         return EntryPoint.runCoverage(javaCommand);
     }
@@ -390,6 +402,9 @@ public class EntryPoint {
                         EntryPoint.blackList.isEmpty() ? ""
                                 : (ParserOptions.FLAG_blackList + ConstantsHelper.WHITE_SPACE
                                 + String.join(ConstantsHelper.PATH_SEPARATOR, EntryPoint.blackList)),
+                        EntryPoint.coverageDetail == ParserOptions.CoverageTransformerDetail.SUMMARIZED ? "" :
+                                (ParserOptions.FLAG_coverage_detail + ConstantsHelper.WHITE_SPACE
+                                 + EntryPoint.coverageDetail.name()),
                 });
         try {
             EntryPoint.runGivenCommandLine(javaCommand);

--- a/src/main/java/eu/stamp_project/testrunner/listener/impl/CoverageCollectorMethodDetailed.java
+++ b/src/main/java/eu/stamp_project/testrunner/listener/impl/CoverageCollectorMethodDetailed.java
@@ -1,0 +1,68 @@
+package eu.stamp_project.testrunner.listener.impl;
+
+import eu.stamp_project.testrunner.listener.Coverage;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
+import org.jacoco.core.analysis.*;
+import org.jacoco.core.data.ExecutionDataStore;
+
+import java.io.*;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class CoverageCollectorMethodDetailed implements CoverageTransformer {
+    @Override
+    public Coverage transformJacocoObject(ExecutionDataStore executionData, String classesDirectory) {
+        final CoverageBuilder coverageBuilder = new CoverageBuilder();
+        final Analyzer analyzer = new Analyzer(executionData, coverageBuilder);
+        try {
+            analyzer.analyzeAll(new File(classesDirectory));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        final int[] counter = new int[2];
+        final StringBuilder builderExecutionPath = new StringBuilder();
+        coverageBuilder.getClasses().forEach(coverage -> {
+            final List<Integer> listOfCountForCounterFunction =
+                    CoverageImpl.getListOfCountForCounterFunction(coverage, ICounter::getCoveredCount);
+            builderExecutionPath.append(coverage.getName())
+                    .append(":")
+                    .append(getCoverageInformationPerMethod(coverage,  ICounter::getCoveredCount))
+                   .append("-");
+            counter[0] += listOfCountForCounterFunction.stream()
+                    .mapToInt(Integer::intValue)
+                    .sum();
+            counter[1] += CoverageImpl.getListOfCountForCounterFunction(coverage, ICounter::getTotalCount)
+                    .stream()
+                    .mapToInt(Integer::intValue)
+                    .sum();
+        });
+
+        Coverage coverage = new CoverageImpl( counter[0], counter[1],builderExecutionPath.toString());
+        return coverage;
+    }
+
+    public static String getCoverageInformationPerMethod(IClassCoverage coverage,
+                                                         Function<ICounter, Integer> counterGetter) {
+        StringBuilder builder = new StringBuilder();
+        coverage.getMethods()
+                .stream()
+                .filter(iMethodCoverage -> !"<clinit>".equals(iMethodCoverage.getName()))
+                .forEach(iMethodCoverage -> {
+                    builder.append(iMethodCoverage.getName()).append("+");
+                    builder.append(iMethodCoverage.getDesc()).append("+");
+                    builder.append(IntStream.range(iMethodCoverage.getFirstLine(), iMethodCoverage.getLastLine() + 1)
+                                            .mapToObj(iMethodCoverage::getLine)
+                                            .map(ILine::getInstructionCounter)
+                                            .map(counterGetter)
+                                            .map(Object::toString)
+                                            .collect(Collectors.joining(",")));
+                    builder.append("|");
+                });
+        if (builder.length() > 0) {
+            builder.replace(builder.length()-1, builder.length(),"");
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/eu/stamp_project/testrunner/listener/impl/CoverageCollectorSummarization.java
+++ b/src/main/java/eu/stamp_project/testrunner/listener/impl/CoverageCollectorSummarization.java
@@ -77,5 +77,4 @@ public class CoverageCollectorSummarization implements CoverageTransformer {
         return coverage;
     }
 
-
 }

--- a/src/main/java/eu/stamp_project/testrunner/listener/impl/CoveragePerTestMethodImpl.java
+++ b/src/main/java/eu/stamp_project/testrunner/listener/impl/CoveragePerTestMethodImpl.java
@@ -2,6 +2,7 @@ package eu.stamp_project.testrunner.listener.impl;
 
 import eu.stamp_project.testrunner.listener.Coverage;
 import eu.stamp_project.testrunner.listener.CoveragePerTestMethod;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
 import eu.stamp_project.testrunner.listener.TestResult;
 import eu.stamp_project.testrunner.runner.Loader;
 import eu.stamp_project.testrunner.utils.ConstantsHelper;
@@ -35,15 +36,19 @@ public class CoveragePerTestMethodImpl implements CoveragePerTestMethod {
 
     protected transient SessionInfoStore sessionInfos;
 
+    protected transient CoverageTransformer coverageTransformer;
+
     public CoveragePerTestMethodImpl() {
         coverageResultsMap = null;
         classesDirectory = null;
+        this.coverageTransformer = new CoverageCollectorSummarization();
     }
 
-    public CoveragePerTestMethodImpl(RuntimeData data, String classesDirectory) {
+    public CoveragePerTestMethodImpl(RuntimeData data, String classesDirectory, CoverageTransformer coverageTransformer) {
         this.data = data;
         this.classesDirectory = classesDirectory;
         this.coverageResultsMap = new HashMap<>();
+        this.coverageTransformer = coverageTransformer;
     }
 
     public String getClassesDirectory() {
@@ -60,6 +65,10 @@ public class CoveragePerTestMethodImpl implements CoveragePerTestMethod {
 
     public SessionInfoStore getSessionInfos() {
         return sessionInfos;
+    }
+
+    public CoverageTransformer getCoverageTransformer() {
+        return coverageTransformer;
     }
 
     public void setData(RuntimeData data) {

--- a/src/main/java/eu/stamp_project/testrunner/listener/junit4/CoveragePerJUnit4TestMethod.java
+++ b/src/main/java/eu/stamp_project/testrunner/listener/junit4/CoveragePerJUnit4TestMethod.java
@@ -2,6 +2,7 @@ package eu.stamp_project.testrunner.listener.junit4;
 
 import eu.stamp_project.testrunner.listener.Coverage;
 import eu.stamp_project.testrunner.listener.CoveragePerTestMethod;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
 import eu.stamp_project.testrunner.listener.impl.CoverageCollectorSummarization;
 import eu.stamp_project.testrunner.listener.impl.CoverageImpl;
 import eu.stamp_project.testrunner.listener.impl.CoveragePerTestMethodImpl;
@@ -43,8 +44,8 @@ public class CoveragePerJUnit4TestMethod extends JUnit4TestResult implements Cov
      */
     private Map<String, List<IClassCoverage>> coveragesPerMethodName;
 
-    public CoveragePerJUnit4TestMethod(RuntimeData data, String classesDirectory) {
-        this.internalCoverage = new CoveragePerTestMethodImpl(data, classesDirectory);
+    public CoveragePerJUnit4TestMethod(RuntimeData data, String classesDirectory, CoverageTransformer coverageTransformer) {
+        this.internalCoverage = new CoveragePerTestMethodImpl(data, classesDirectory, coverageTransformer);
         this.coveragesPerMethodName = new HashMap<>();
     }
 
@@ -73,8 +74,10 @@ public class CoveragePerJUnit4TestMethod extends JUnit4TestResult implements Cov
                 this.internalCoverage.getSessionInfos(),
                 false
         );
-        CoverageCollectorSummarization coverageBilder = new CoverageCollectorSummarization();     
-        Coverage jUnit4Coverage =  coverageBilder.transformJacocoObject(this.internalCoverage.getExecutionData(), this.internalCoverage.getClassesDirectory());
+
+        Coverage jUnit4Coverage =
+                internalCoverage.getCoverageTransformer().transformJacocoObject(this.internalCoverage.getExecutionData(),
+                        this.internalCoverage.getClassesDirectory());
         this.internalCoverage.getCoverageResultsMap().put(description.getMethodName(), jUnit4Coverage);
         if (isParametrized.test(description.getMethodName())) {
             this.collectForParametrizedTest(fromParametrizedToSimpleName.apply(description.getMethodName()));

--- a/src/main/java/eu/stamp_project/testrunner/listener/junit5/CoveragePerJUnit5TestMethod.java
+++ b/src/main/java/eu/stamp_project/testrunner/listener/junit5/CoveragePerJUnit5TestMethod.java
@@ -2,6 +2,7 @@ package eu.stamp_project.testrunner.listener.junit5;
 
 import eu.stamp_project.testrunner.listener.Coverage;
 import eu.stamp_project.testrunner.listener.CoveragePerTestMethod;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
 import eu.stamp_project.testrunner.listener.impl.CoverageCollectorSummarization;
 import eu.stamp_project.testrunner.listener.impl.CoveragePerTestMethodImpl;
 import eu.stamp_project.testrunner.runner.Failure;
@@ -27,8 +28,8 @@ public class CoveragePerJUnit5TestMethod extends JUnit5TestResult implements Cov
     private CoveragePerTestMethodImpl internalCoverage;
 
 
-    public CoveragePerJUnit5TestMethod(RuntimeData data, String classesDirectory) {
-        this.internalCoverage = new CoveragePerTestMethodImpl(data, classesDirectory);
+    public CoveragePerJUnit5TestMethod(RuntimeData data, String classesDirectory, CoverageTransformer coverageTransformer) {
+        this.internalCoverage = new CoveragePerTestMethodImpl(data, classesDirectory, coverageTransformer);
     }
 
     @Override
@@ -54,9 +55,10 @@ public class CoveragePerJUnit5TestMethod extends JUnit5TestResult implements Cov
                     this.internalCoverage.getSessionInfos(),
                     false
             );
-       
-            CoverageCollectorSummarization coverageBuilder = new CoverageCollectorSummarization();
-            Coverage jUnit5Coverage =  coverageBuilder.transformJacocoObject(this.internalCoverage.getExecutionData(), this.internalCoverage.getClassesDirectory());
+
+            Coverage jUnit5Coverage =
+                    internalCoverage.getCoverageTransformer().transformJacocoObject(this.internalCoverage.getExecutionData(),
+                            this.internalCoverage.getClassesDirectory());
             this.internalCoverage.getCoverageResultsMap().put(this.toString.apply(testIdentifier), jUnit5Coverage);
             switch (testExecutionResult.getStatus()) {
                 case FAILED:

--- a/src/main/java/eu/stamp_project/testrunner/runner/ParserOptions.java
+++ b/src/main/java/eu/stamp_project/testrunner/runner/ParserOptions.java
@@ -1,5 +1,10 @@
 package eu.stamp_project.testrunner.runner;
 
+import eu.stamp_project.testrunner.listener.Coverage;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
+import eu.stamp_project.testrunner.listener.impl.CoverageCollectorDetailed;
+import eu.stamp_project.testrunner.listener.impl.CoverageCollectorMethodDetailed;
+import eu.stamp_project.testrunner.listener.impl.CoverageCollectorSummarization;
 import eu.stamp_project.testrunner.utils.ConstantsHelper;
 
 import java.util.ArrayList;
@@ -37,6 +42,9 @@ public class ParserOptions {
                 case FLAG_blackList:
                     parserOptions.blackList = convertArrayToList.apply(args[++i]);
                     break;
+                case FLAG_coverage_detail:
+                    parserOptions.coverageTransformerDetail = CoverageTransformerDetail.valueOf(args[++i]);
+                    break;
                 case " ":
                 case "":
                     break;
@@ -63,6 +71,9 @@ public class ParserOptions {
 
         usage.append(FLAG_blackList).append(ConstantsHelper.WHITE_SPACE)
                 .append(FLAG_HELP_blackList).append(ConstantsHelper.LINE_SEPARATOR);
+
+        usage.append(FLAG_coverage_detail).append(ConstantsHelper.WHITE_SPACE)
+             .append(FLAG_HELP_coverage_detail).append(ConstantsHelper.LINE_SEPARATOR);
 
         System.out.println(usage.toString());
     }
@@ -107,11 +118,31 @@ public class ParserOptions {
 
     public static final String FLAG_HELP_blackList = "This flag must be followed by the list of simple names of test methods to NOT be run. Names must be separated by the system path separator, e.g. ':' on Linux";
 
+
+
+    public enum CoverageTransformerDetail {
+        SUMMARIZED,
+        DETAIL,
+        METHOD_DETAIL
+    }
+    /**
+     * This value represents at which level of detail coverage information should be provided
+     */
+    private CoverageTransformerDetail coverageTransformerDetail;
+
+    public static final String FLAG_coverage_detail = "--coverage-detail";
+
+    public static final String FLAG_HELP_coverage_detail = "The value following this flag defines the level of detail" +
+                                                           " provided in the coverage information. Valid values:" +
+                                                           "'SUMMARIZED' (default), 'DETAIL' or 'METHOD_DETAIL'.";
+
+
     private ParserOptions() {
         this.pathToCompiledClassesOfTheProject = "";
         this.fullQualifiedNameOfTestClassesToRun = new String[]{};
         this.testMethodNamesToRun = new String[]{};
         this.blackList = new ArrayList<>();
+        this.coverageTransformerDetail = CoverageTransformerDetail.SUMMARIZED;
     }
 
     public String getPathToCompiledClassesOfTheProject() {
@@ -128,6 +159,19 @@ public class ParserOptions {
 
     public List<String> getBlackList() {
         return blackList;
+    }
+
+    public CoverageTransformer getCoverageTransformer() {
+        switch (coverageTransformerDetail) {
+            case DETAIL:
+                return new CoverageCollectorDetailed();
+            case METHOD_DETAIL:
+                return new CoverageCollectorMethodDetailed();
+            case SUMMARIZED:
+            default:
+                return new CoverageCollectorSummarization();
+        }
+
     }
 
 }

--- a/src/main/java/eu/stamp_project/testrunner/runner/coverage/JUnit4JacocoRunner.java
+++ b/src/main/java/eu/stamp_project/testrunner/runner/coverage/JUnit4JacocoRunner.java
@@ -1,6 +1,7 @@
 package eu.stamp_project.testrunner.runner.coverage;
 
 import eu.stamp_project.testrunner.EntryPoint;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
 import eu.stamp_project.testrunner.listener.CoveredTestResult;
 import eu.stamp_project.testrunner.listener.junit4.JUnit4Coverage;
 import eu.stamp_project.testrunner.listener.junit4.JUnit4TestResult;
@@ -17,12 +18,12 @@ import java.util.List;
  */
 public class JUnit4JacocoRunner extends JacocoRunner {
 
-    public JUnit4JacocoRunner(String classesDirectory, String testClassesDirectory) {
-        super(classesDirectory, testClassesDirectory);
+    public JUnit4JacocoRunner(String classesDirectory, String testClassesDirectory, CoverageTransformer coverageTransformer) {
+        super(classesDirectory, testClassesDirectory, coverageTransformer);
     }
     
-    public JUnit4JacocoRunner(String classesDirectory, String testClassesDirectory, List<String> blackList) {
-        super(classesDirectory, testClassesDirectory, blackList);
+    public JUnit4JacocoRunner(String classesDirectory, String testClassesDirectory, List<String> blackList, CoverageTransformer coverageTransformer) {
+        super(classesDirectory, testClassesDirectory, blackList, coverageTransformer);
     }
 
     /**
@@ -38,7 +39,8 @@ public class JUnit4JacocoRunner extends JacocoRunner {
         final JacocoRunner jacocoRunner =
                 new JUnit4JacocoRunner(classesDirectory,
                         testClassesDirectory,
-                        options.getBlackList()
+                        options.getBlackList(),
+                        options.getCoverageTransformer()
                 );
         final String[] testClassesToRun = options.getFullQualifiedNameOfTestClassesToRun();
         if (testClassesToRun.length > 1) {

--- a/src/main/java/eu/stamp_project/testrunner/runner/coverage/JUnit4JacocoRunnerPerTestMethod.java
+++ b/src/main/java/eu/stamp_project/testrunner/runner/coverage/JUnit4JacocoRunnerPerTestMethod.java
@@ -2,6 +2,7 @@ package eu.stamp_project.testrunner.runner.coverage;
 
 import eu.stamp_project.testrunner.EntryPoint;
 import eu.stamp_project.testrunner.listener.CoveragePerTestMethod;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
 import eu.stamp_project.testrunner.listener.junit4.CoveragePerJUnit4TestMethod;
 import eu.stamp_project.testrunner.listener.junit4.JUnit4TestResult;
 import eu.stamp_project.testrunner.runner.JUnit4Runner;
@@ -19,8 +20,8 @@ import java.util.List;
  */
 public class JUnit4JacocoRunnerPerTestMethod extends JacocoRunnerPerTestMethod {
 
-    public JUnit4JacocoRunnerPerTestMethod(String classesDirectory, String testClassesDirectory, List<String> blackList) {
-        super(classesDirectory, testClassesDirectory, blackList);
+    public JUnit4JacocoRunnerPerTestMethod(String classesDirectory, String testClassesDirectory, List<String> blackList, CoverageTransformer coverageTransformer) {
+        super(classesDirectory, testClassesDirectory, blackList, coverageTransformer);
     }
 
     @Override
@@ -28,7 +29,7 @@ public class JUnit4JacocoRunnerPerTestMethod extends JacocoRunnerPerTestMethod {
                                                              String classesDirectory,
                                                              String[] testClassNames,
                                                              String[] testMethodNames) {
-        final CoveragePerTestMethod listener = new CoveragePerJUnit4TestMethod(data, classesDirectory);
+        final CoveragePerTestMethod listener = new CoveragePerJUnit4TestMethod(data, classesDirectory, coverageTransformer);
         JUnit4Runner.run(
                 testClassNames,
                 testMethodNames,
@@ -52,7 +53,8 @@ public class JUnit4JacocoRunnerPerTestMethod extends JacocoRunnerPerTestMethod {
         new JUnit4JacocoRunnerPerTestMethod(
                 classesDirectory,
                 testClassesDirectory,
-                options.getBlackList()
+                options.getBlackList(),
+                options.getCoverageTransformer()
         ).runCoveragePerTestMethod(classesDirectory,
                 testClassesDirectory,
                 options.getFullQualifiedNameOfTestClassesToRun()[0],

--- a/src/main/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunner.java
+++ b/src/main/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunner.java
@@ -1,6 +1,7 @@
 package eu.stamp_project.testrunner.runner.coverage;
 
 import eu.stamp_project.testrunner.EntryPoint;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
 import eu.stamp_project.testrunner.listener.CoveredTestResult;
 import eu.stamp_project.testrunner.listener.junit5.JUnit5Coverage;
 import eu.stamp_project.testrunner.runner.JUnit5Runner;
@@ -17,12 +18,12 @@ import java.util.List;
 public class JUnit5JacocoRunner extends JacocoRunner {
 
 	
-    public JUnit5JacocoRunner(String classesDirectory, String testClassesDirectory) {
-        super(classesDirectory, testClassesDirectory);
+    public JUnit5JacocoRunner(String classesDirectory, String testClassesDirectory, CoverageTransformer coverageTransformer) {
+        super(classesDirectory, testClassesDirectory, coverageTransformer);
     }
     
-    public JUnit5JacocoRunner(String classesDirectory, String testClassesDirectory, List<String> blackList) {
-        super(classesDirectory, testClassesDirectory, blackList);;
+    public JUnit5JacocoRunner(String classesDirectory, String testClassesDirectory, List<String> blackList, CoverageTransformer coverageTransformer) {
+        super(classesDirectory, testClassesDirectory, blackList, coverageTransformer);;
     }
 
     
@@ -40,7 +41,8 @@ public class JUnit5JacocoRunner extends JacocoRunner {
         final JacocoRunner jacocoRunner =
                 new JUnit5JacocoRunner(classesDirectory,
                         testClassesDirectory,
-                        options.getBlackList()
+                        options.getBlackList(),
+                        options.getCoverageTransformer()
                 );
         final String[] testClassesToRun = options.getFullQualifiedNameOfTestClassesToRun();
         if (testClassesToRun.length > 1) {

--- a/src/main/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunnerPerTestMethod.java
+++ b/src/main/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunnerPerTestMethod.java
@@ -2,6 +2,7 @@ package eu.stamp_project.testrunner.runner.coverage;
 
 import eu.stamp_project.testrunner.EntryPoint;
 import eu.stamp_project.testrunner.listener.CoveragePerTestMethod;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
 import eu.stamp_project.testrunner.listener.junit5.CoveragePerJUnit5TestMethod;
 import eu.stamp_project.testrunner.runner.JUnit5Runner;
 import eu.stamp_project.testrunner.runner.ParserOptions;
@@ -18,8 +19,8 @@ import java.util.List;
  */
 public class JUnit5JacocoRunnerPerTestMethod extends JacocoRunnerPerTestMethod {
 
-    public JUnit5JacocoRunnerPerTestMethod(String classesDirectory, String testClassesDirectory, List<String> blackList) {
-        super(classesDirectory, testClassesDirectory, blackList);
+    public JUnit5JacocoRunnerPerTestMethod(String classesDirectory, String testClassesDirectory, List<String> blackList, CoverageTransformer coverageTransformer) {
+        super(classesDirectory, testClassesDirectory, blackList, coverageTransformer);
     }
 
     @Override
@@ -27,7 +28,7 @@ public class JUnit5JacocoRunnerPerTestMethod extends JacocoRunnerPerTestMethod {
                                                              String classesDirectory,
                                                              String[] testClassNames,
                                                              String[] testMethodNames) {
-        final CoveragePerJUnit5TestMethod listener = new CoveragePerJUnit5TestMethod(data, classesDirectory);
+        final CoveragePerJUnit5TestMethod listener = new CoveragePerJUnit5TestMethod(data, classesDirectory, coverageTransformer);
         JUnit5Runner.run(
                 testClassNames,
                 testMethodNames,
@@ -51,7 +52,8 @@ public class JUnit5JacocoRunnerPerTestMethod extends JacocoRunnerPerTestMethod {
         new JUnit5JacocoRunnerPerTestMethod(
                 classesDirectory,
                 testClassesDirectory,
-                options.getBlackList()
+                options.getBlackList(),
+                options.getCoverageTransformer()
         ).runCoveragePerTestMethod(classesDirectory,
                 testClassesDirectory,
                 options.getFullQualifiedNameOfTestClassesToRun()[0],

--- a/src/main/java/eu/stamp_project/testrunner/runner/coverage/JacocoRunnerPerTestMethod.java
+++ b/src/main/java/eu/stamp_project/testrunner/runner/coverage/JacocoRunnerPerTestMethod.java
@@ -2,6 +2,7 @@ package eu.stamp_project.testrunner.runner.coverage;
 
 import eu.stamp_project.testrunner.EntryPoint;
 import eu.stamp_project.testrunner.listener.CoveragePerTestMethod;
+import eu.stamp_project.testrunner.listener.CoverageTransformer;
 import eu.stamp_project.testrunner.listener.CoveredTestResult;
 import eu.stamp_project.testrunner.listener.TestResult;
 import eu.stamp_project.testrunner.runner.Failure;
@@ -85,8 +86,8 @@ public abstract class JacocoRunnerPerTestMethod extends JacocoRunner {
      * @param classesDirectory     the path to the directory that contains the .class file of sources
      * @param testClassesDirectory the path to the directory that contains the .class file of test sources
      */
-    public JacocoRunnerPerTestMethod(String classesDirectory, String testClassesDirectory) {
-        super(classesDirectory, testClassesDirectory);
+    public JacocoRunnerPerTestMethod(String classesDirectory, String testClassesDirectory, CoverageTransformer coverageTransformer) {
+        super(classesDirectory, testClassesDirectory, coverageTransformer);
     }
 
     /**
@@ -94,7 +95,7 @@ public abstract class JacocoRunnerPerTestMethod extends JacocoRunner {
      * @param testClassesDirectory the path to the directory that contains the .class file of test sources
      * @param blackList            the names of the test methods to NOT be run.
      */
-    public JacocoRunnerPerTestMethod(String classesDirectory, String testClassesDirectory, List<String> blackList) {
-        super(classesDirectory, testClassesDirectory, blackList);
+    public JacocoRunnerPerTestMethod(String classesDirectory, String testClassesDirectory, List<String> blackList, CoverageTransformer coverageTransformer) {
+        super(classesDirectory, testClassesDirectory, blackList, coverageTransformer);
     }
 }

--- a/src/test/java/eu/stamp_project/testrunner/listener/CoverageTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/listener/CoverageTest.java
@@ -1,0 +1,48 @@
+package eu.stamp_project.testrunner.listener;
+
+import eu.stamp_project.testrunner.AbstractTest;
+import eu.stamp_project.testrunner.listener.impl.CoverageImpl;
+import eu.stamp_project.testrunner.runner.ParserOptions;
+import eu.stamp_project.testrunner.runner.coverage.JUnit4JacocoRunner;
+import eu.stamp_project.testrunner.utils.ConstantsHelper;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CoverageTest extends AbstractTest {
+
+    @Test
+    public void compareTwoCoverages() throws Exception {
+
+        /*
+            Using the api to compute the coverage on a test class
+         */
+
+        JUnit4JacocoRunner.main(new String[]{
+                        ParserOptions.FLAG_pathToCompiledClassesOfTheProject, TEST_PROJECT_CLASSES,
+                        ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample",
+                        ParserOptions.FLAG_testMethodNamesToRun, "test4"
+                }
+        );
+        final Coverage test4Coverage = CoverageImpl.load();
+
+        JUnit4JacocoRunner.main(new String[]{
+                        ParserOptions.FLAG_pathToCompiledClassesOfTheProject, TEST_PROJECT_CLASSES,
+                        ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample",
+                        ParserOptions.FLAG_testMethodNamesToRun, "test8"
+                }
+        );
+        final Coverage test8Coverage = CoverageImpl.load();
+
+        assertTrue(test4Coverage.getInstructionsCovered() > test8Coverage.getInstructionsCovered());
+        assertEquals(test4Coverage.getInstructionsTotal(),test8Coverage.getInstructionsTotal());
+        assertTrue(test4Coverage.isBetterThan(test8Coverage));
+
+        System.out.println("------- TEST 4 COVERAGE -------");
+        System.out.println(String.join(ConstantsHelper.LINE_SEPARATOR, test4Coverage.getExecutionPath().split(";")));
+
+        System.out.println("------- TEST 8 COVERAGE -------");
+        System.out.println(String.join(ConstantsHelper.LINE_SEPARATOR, test8Coverage.getExecutionPath().split(";")));
+    }
+}

--- a/src/test/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunnerTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunnerTest.java
@@ -34,7 +34,7 @@ public class JUnit5JacocoRunnerTest extends AbstractTest {
         final Coverage load = CoverageImpl.load();
         assertEquals(30, load.getInstructionsCovered());
         assertEquals(EntryPointTest.NUMBER_OF_INSTRUCTIONS, load.getInstructionsTotal());
-        assertEquals(expectedExecutionPath , load.getExecutionPath());
+        assertEquals(expectedExecutionPath, load.getExecutionPath());
     }
 
     private static final String expectedExecutionPath = "tobemocked/LoginDao:0,0;tobemocked/LoginController:0,0,0,0,0,0,0,0,0,0,0,0,0,0,0;tobemocked/LoginService:0,0,0,0,0,0,0,0,0,0,0,0,0,0;example/Example:2,0,0,4,4,0,7,2,0,2,5,1,0,3;tobemocked/UserForm:0,0;";
@@ -74,6 +74,29 @@ public class JUnit5JacocoRunnerTest extends AbstractTest {
         final Coverage load = CoverageImpl.load();
         assertEquals(23, load.getInstructionsCovered());
         assertEquals(EntryPointTest.NUMBER_OF_INSTRUCTIONS, load.getInstructionsTotal());
+    }
+
+
+    private static final String expectedMethodDetailedExecutionPath = "tobemocked/LoginDao:<init>+()V+0|login+" +
+            "(Ltobemocked/UserForm;)I+0-tobemocked/LoginController:<init>+()V+0|" +
+            "login+(Ltobemocked/UserForm;)Ljava/lang/String;+0,0,0,0,0,0,0,0,0,0,0,0,0,0" +
+            "-tobemocked/LoginService:<init>+()V+0|login+(Ltobemocked/UserForm;)Z+0,0,0,0,0,0,0|" +
+            "setCurrentUser+(Ljava/lang/String;)V+0,0,0,0|setLoginDao+(Ltobemocked/LoginDao;)V+0,0" +
+            "-example/Example:charAt+(Ljava/lang/String;I)C+2,0,0,4,4,0,7|<init>+()V+2,0,2,5,1,0,3" +
+            "-tobemocked/UserForm:<init>+()V+0|getUsername+()Ljava/lang/String;+0-";
+
+
+    @Test
+    public void testMethodDetailedCoverageDetail() throws Exception {
+
+        JUnit5JacocoRunner.main(new String[]{
+                        ParserOptions.FLAG_pathToCompiledClassesOfTheProject, TEST_PROJECT_CLASSES,
+                        ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "junit5.TestSuiteExample",
+                        ParserOptions.FLAG_coverage_detail, ParserOptions.CoverageTransformerDetail.METHOD_DETAIL.name(),
+                }
+        );
+        final Coverage load = CoverageImpl.load();
+        assertEquals(expectedMethodDetailedExecutionPath, load.getExecutionPath());
     }
 
 }


### PR DESCRIPTION
(includes / dependent on #87)

Good afternoon 😊

For [Test Cube](https://github.com/TestShiftProject/test-cube) I needed more detailed coverage information, specifically the instruction coverage reported per method.
I adapted my modifications to fit @martinezmatias new coverage transformers and added an option to specify which coverage transformer should be used.

Included a test for the new method-detailed coverage and a more general test to help me understand the comparison of two coverages.