### PR TITLE
Bump `org.jacoco.core` to `0.8.7`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,27 +92,27 @@
         <dependency>
             <groupId>org.pitest</groupId>
             <artifactId>pitest-entry</artifactId>
-            <version>1.4.7</version>
+            <version>1.6.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.pitest</groupId>
             <artifactId>pitest</artifactId>
-            <version>1.4.7</version>
+            <version>1.6.7</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.10.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jacoco/org.jacoco.core -->
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.core</artifactId>
-            <version>0.8.3</version>
+            <version>0.8.7</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/src/test/java/eu/stamp_project/testrunner/EntryPointJUnit5Test.java
+++ b/src/test/java/eu/stamp_project/testrunner/EntryPointJUnit5Test.java
@@ -299,11 +299,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
             Test the runCoverage() of EntryPoint.
                 It should return the CoverageResult with the instruction jUnit4Coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final Coverage coverage = EntryPoint.runCoverage(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -322,11 +318,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
             Test the runCoverage() of EntryPoint.
                 It should return the CoverageResult with the instruction jUnit4Coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final Coverage coverage = EntryPoint.runCoverage(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -346,11 +338,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
             Test the runCoverage() of EntryPoint.
                 It should return the CoverageResult with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final Coverage coverage = EntryPoint.runCoverage(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -369,11 +357,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
         /*
             Test the runCoverage() of EntryPoint with blacklisted test methods.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         EntryPoint.blackList.add("test8");
         EntryPoint.blackList.add("test6");
@@ -399,10 +383,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
             Test the runCoveragePerTestMethods() of EntryPoint.
                 It should return the CoverageResult with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveragePerTestMethod coveragePerTestMethod = EntryPoint.runCoveragePerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -424,10 +405,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
             Test the runCoveragePerTestMethods() of EntryPoint.
                 It should return the CoverageResult with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveragePerTestMethod coveragePerTestMethod = EntryPoint.runCoveragePerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -450,10 +428,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
             Test the runCoveragePerTestMethods() of EntryPoint.
                 It should return the CoverageResult with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveragePerTestMethod coveragePerTestMethod = EntryPoint.runCoveragePerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -477,10 +452,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
             Test the runCoveredTestResultPerTestMethods() of EntryPoint.
                 It should return the CoveredTestResultPerTestMethod with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveredTestResultPerTestMethod coveredTestResultPerTestMethod = EntryPoint.runCoveredTestResultPerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -512,10 +484,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
             Test the runCoveredTestResultPerTestMethods() of EntryPoint.
                 It should return the CoveredTestResultPerTestMethod with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveredTestResultPerTestMethod coveredTestResultPerTestMethod = EntryPoint.runCoveredTestResultPerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -553,10 +522,7 @@ public class EntryPointJUnit5Test extends AbstractTest {
             Test the runCoveredTestResultPerTestMethods() of EntryPoint.
                 It should return the CoveredTestResultPerTestMethod with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveredTestResultPerTestMethod coveredTestResultPerTestMethod = EntryPoint.runCoveredTestResultPerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,

--- a/src/test/java/eu/stamp_project/testrunner/EntryPointTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/EntryPointTest.java
@@ -335,11 +335,7 @@ public class EntryPointTest extends AbstractTest {
             Test the runCoverage() of EntryPoint.
                 It should return the CoverageResult with the instruction jUnit4Coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
-        ;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final Coverage coverage = EntryPoint.runCoverage(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -358,11 +354,7 @@ public class EntryPointTest extends AbstractTest {
             Test the runCoverage() of EntryPoint.
                 It should return the CoverageResult with the instruction jUnit4Coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
-        ;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final Coverage coverage = EntryPoint.runCoverage(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -381,10 +373,7 @@ public class EntryPointTest extends AbstractTest {
             Test the runCoverage() of EntryPoint.
                 It should return the CoverageResult with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final Coverage coverage = EntryPoint.runCoverage(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -402,11 +391,7 @@ public class EntryPointTest extends AbstractTest {
         /*
             Test the runCoverage() of EntryPoint with blacklisted test methods.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
-        ;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         EntryPoint.blackList.add("test8");
         EntryPoint.blackList.add("test6");
@@ -432,10 +417,7 @@ public class EntryPointTest extends AbstractTest {
             Test the runCoveragePerTestMethods() of EntryPoint.
                 It should return the CoverageResult with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveragePerTestMethod coveragePerTestMethod = EntryPoint.runCoveragePerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -457,10 +439,7 @@ public class EntryPointTest extends AbstractTest {
             Test the runCoveragePerTestMethods() of EntryPoint.
                 It should return the CoverageResult with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveragePerTestMethod coveragePerTestMethod = EntryPoint.runCoveragePerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -469,6 +448,7 @@ public class EntryPointTest extends AbstractTest {
                 new String[]{"example.TestSuiteExample#test3", "example.TestSuiteExample2#test3"}
         );
 
+        System.out.println(coveragePerTestMethod);
         assertEquals(23, coveragePerTestMethod.getCoverageOf("example.TestSuiteExample#test3").getInstructionsCovered());
         assertEquals(NUMBER_OF_INSTRUCTIONS, coveragePerTestMethod.getCoverageOf("example.TestSuiteExample#test3").getInstructionsTotal());
         assertEquals(23, coveragePerTestMethod.getCoverageOf("example.TestSuiteExample2#test3").getInstructionsCovered());
@@ -530,10 +510,7 @@ public class EntryPointTest extends AbstractTest {
             Test the runCoveredTestResultPerTestMethods() of EntryPoint.
                 It should return the CoveredTestResult with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveredTestResultPerTestMethod coveredTestResultPerTestMethod = EntryPoint.runCoveredTestResultPerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -607,10 +584,7 @@ public class EntryPointTest extends AbstractTest {
             Test the runCoveredTestResultPerTestMethods() of EntryPoint.
                 It should return the CoveredTestResult with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveredTestResultPerTestMethod coveredTestResultPerTestMethod = EntryPoint.runCoveredTestResultPerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,
@@ -647,10 +621,7 @@ public class EntryPointTest extends AbstractTest {
             Test the runCoveredTestResultPerTestMethods() of EntryPoint.
                 It should return the CoveredTestResultPerTestMethod with the instruction coverage computed by Jacoco.
          */
-        final String classpath = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.7.9/org.jacoco.core-0.7.9.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "org/ow2/asm/asm-debug-all/5.2/asm-debug-all-5.2.jar" + ConstantsHelper.PATH_SEPARATOR +
-                MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar" + ConstantsHelper.PATH_SEPARATOR +
-                JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
+        final String classpath = JUNIT_CP + ConstantsHelper.PATH_SEPARATOR + JUNIT5_CP;
 
         final CoveredTestResultPerTestMethod coveredTestResultPerTestMethod = EntryPoint.runCoveredTestResultPerTestMethods(
                 classpath + ConstantsHelper.PATH_SEPARATOR + TEST_PROJECT_CLASSES,


### PR DESCRIPTION
Remove explicit dependencies from unit tests, as they are calculated in `EntryPoint`.

Bump other dependencies due to conflicts:
- Bump `commons-io` to `2.10.0`.
- Bump `pitest` to `1.6.7`.
- Bump `pitest-entry` to `1.6.7`.