### PR TITLE
Add matrix to workflows and update JDK distribution

### DIFF
--- a/.github/workflows/mvn-build-action.yml
+++ b/.github/workflows/mvn-build-action.yml
@@ -6,13 +6,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java-version: [ 8 ,  11 , 16 , 17, 18 ]
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v3.0.0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
       - name: Build with Maven
         run: ./src/update-classes-in-resources.sh
       - name: Prepare resources binaries
@@ -20,4 +24,4 @@ jobs:
       - name: Export MAVEN_HOME, run tests and collect coverage
         run: export MAVEN_HOME=`mvn --version | grep 'Maven home' | sed -e 's/Maven h.* //'` && echo "🎉 ${MAVEN_HOME}" && mvn test jacoco:report
       - name: Report coverage to Codecov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,12 +19,12 @@ jobs:
           # Reference: https://github.com/lewagon/wait-on-check-action#running-workflow-name
           running-workflow-name: 'Publish package'
           repo-token: ${{ secrets.TOKEN_GITHUB }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.0
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v4

--- a/pom.xml
+++ b/pom.xml
@@ -183,10 +183,11 @@
             <version>0.8</version>
         </dependency>
 
+        <!-- for testing System.exit -->
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
+            <artifactId>system-lambda</artifactId>
+            <version>1.2.1</version>
         </dependency>
 
     </dependencies>
@@ -290,6 +291,35 @@
 
 
     <profiles>
+        <profile>
+            <id>surefire-java16-and-below</id>
+            <activation>
+                <jdk>(,17)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>surefire-java17-and-above</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>-Djava.security.manager=allow</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>coveralls</id>
             <build>

--- a/src/test/java/eu/stamp_project/testrunner/AbstractTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/AbstractTest.java
@@ -4,10 +4,6 @@ import eu.stamp_project.testrunner.utils.ConstantsHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
 import spoon.Launcher;
 
 import java.io.File;
@@ -21,10 +17,6 @@ import java.util.List;
  * on 19/12/17
  */
 public class AbstractTest {
-
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
-    @Rule
-    public TestRule allRules = RuleChain.emptyRuleChain().around(exit);
 
     public static String MAVEN_HOME;
 

--- a/src/test/java/eu/stamp_project/testrunner/AbstractTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/AbstractTest.java
@@ -127,4 +127,19 @@ public class AbstractTest {
         }
     }
 
+    public static int getJavaVersion() {
+        String version = System.getProperty("java.version");
+
+        // Java 8 or lower: 1.6.0_23, 1.7.0, 1.7.0_80, 1.8.0_211
+        // Java 9 or higher: 9.0.1, 11.0.4, 12, 12.0.1
+        if(version.startsWith("1.")) {
+            version = version.substring(2, 3);
+        } else {
+            int dot = version.indexOf(".");
+            if(dot != -1) { version = version.substring(0, dot); }
+        }
+
+        return Integer.parseInt(version);
+    }
+
 }

--- a/src/test/java/eu/stamp_project/testrunner/AbstractTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/AbstractTest.java
@@ -4,7 +4,6 @@ import eu.stamp_project.testrunner.utils.ConstantsHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.rules.RuleChain;
@@ -12,14 +11,9 @@ import org.junit.rules.TestRule;
 import spoon.Launcher;
 
 import java.io.File;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Created by Benjamin DANGLOT
@@ -45,8 +39,7 @@ public class AbstractTest {
     public static String JUNIT5_CP;
 
     {
-        List<String> classPath = Arrays.stream(((URLClassLoader) URLClassLoader.getSystemClassLoader()).getURLs())
-                .map(URL::getPath).collect(Collectors.toList());
+        List<String> classPath = Arrays.asList(System.getProperty("java.class.path").split(System.getProperty("path.separator")));
 
         System.out.println(classPath);
         if (classPath.size() == 1) {

--- a/src/test/java/eu/stamp_project/testrunner/AbstractTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/AbstractTest.java
@@ -51,8 +51,8 @@ public class AbstractTest {
         TEST_PROJECT_CLASSES = "src/test/resources/test-projects/target/test-classes/";
         JUNIT_CP = MAVEN_HOME + "junit/junit/4.12/junit-4.12.jar" + ConstantsHelper.PATH_SEPARATOR
                 + MAVEN_HOME + "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar";
-        EASYMOCK_CP = MAVEN_HOME + "org/easymock/easymock/3.4/easymock-3.4.jar" + ConstantsHelper.PATH_SEPARATOR
-                + MAVEN_HOME + "org/objenesis/objenesis/2.2/objenesis-2.2.jar";
+        EASYMOCK_CP = MAVEN_HOME + "org/easymock/easymock/4.3/easymock-4.3.jar" + ConstantsHelper.PATH_SEPARATOR
+                + MAVEN_HOME + "org/objenesis/objenesis/3.2/objenesis-3.2.jar";
         JUNIT5_CP =
                 MAVEN_HOME + "org/junit/jupiter/junit-jupiter-api/5.3.2/junit-jupiter-api-5.3.2.jar" + ConstantsHelper.PATH_SEPARATOR
                         + MAVEN_HOME + "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar" + ConstantsHelper.PATH_SEPARATOR

--- a/src/test/java/eu/stamp_project/testrunner/EntryPointTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/EntryPointTest.java
@@ -5,26 +5,21 @@ import eu.stamp_project.testrunner.listener.CoveragePerTestMethod;
 import eu.stamp_project.testrunner.listener.CoveredTestResultPerTestMethod;
 import eu.stamp_project.testrunner.listener.TestResult;
 import eu.stamp_project.testrunner.listener.impl.CoverageDetailed;
-import eu.stamp_project.testrunner.listener.impl.CoverageFromClass;
 import eu.stamp_project.testrunner.listener.pit.AbstractPitResult;
 import eu.stamp_project.testrunner.runner.Failure;
 import eu.stamp_project.testrunner.runner.ParserOptions;
 import eu.stamp_project.testrunner.utils.ConstantsHelper;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Created by Benjamin DANGLOT

--- a/src/test/java/eu/stamp_project/testrunner/EntryPointTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/EntryPointTest.java
@@ -9,10 +9,7 @@ import eu.stamp_project.testrunner.listener.pit.AbstractPitResult;
 import eu.stamp_project.testrunner.runner.Failure;
 import eu.stamp_project.testrunner.runner.ParserOptions;
 import eu.stamp_project.testrunner.utils.ConstantsHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -194,6 +191,7 @@ public class EntryPointTest extends AbstractTest {
 
     @Test
     public void testOnEasyMockTests() throws Exception {
+        Assume.assumeTrue(getJavaVersion() <= 11);
 
         /*
             Test to run test class that use easymock framework

--- a/src/test/java/eu/stamp_project/testrunner/listener/CoverageTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/listener/CoverageTest.java
@@ -5,12 +5,9 @@ import eu.stamp_project.testrunner.listener.impl.CoverageImpl;
 import eu.stamp_project.testrunner.runner.ParserOptions;
 import eu.stamp_project.testrunner.runner.coverage.JUnit4JacocoRunner;
 import eu.stamp_project.testrunner.utils.ConstantsHelper;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -23,24 +20,24 @@ public class CoverageTest extends AbstractTest {
             Using the api to compute the coverage on a test class
          */
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit4JacocoRunner.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit4JacocoRunner.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample",
                         ParserOptions.FLAG_testMethodNamesToRun, "test4"
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final Coverage test4Coverage = CoverageImpl.load();
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit4JacocoRunner.main(new String[]{
+        statusCode = catchSystemExit(() -> JUnit4JacocoRunner.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample",
                         ParserOptions.FLAG_testMethodNamesToRun, "test8"
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final Coverage test8Coverage = CoverageImpl.load();
 
         assertTrue(test4Coverage.getInstructionsCovered() > test8Coverage.getInstructionsCovered());

--- a/src/test/java/eu/stamp_project/testrunner/runner/coverage/JUnit4JacocoRunnerCoveredResultPerTestMethodTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/runner/coverage/JUnit4JacocoRunnerCoveredResultPerTestMethodTest.java
@@ -7,6 +7,7 @@ import eu.stamp_project.testrunner.runner.ParserOptions;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -23,14 +24,14 @@ public class JUnit4JacocoRunnerCoveredResultPerTestMethodTest extends AbstractTe
             Using the api to compute the coverage on a test class
          */
 
-		exit.expectSystemExitWithStatus(0);
-		JUnit4JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
+		int statusCode = catchSystemExit(() -> JUnit4JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
 						ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
 						ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
 						ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.ParametrizedTest",
 						ParserOptions.FLAG_testMethodNamesToRun, "test"
 				}
-		);
+		));
+		assertEquals(0, statusCode);
 		final CoveredTestResultPerTestMethod load = CoveredTestResultPerTestMethodImpl.load();
 		System.out.println(load);
 
@@ -56,14 +57,14 @@ public class JUnit4JacocoRunnerCoveredResultPerTestMethodTest extends AbstractTe
             Using the api to compute the coverage on test cases
          */
 
-		exit.expectSystemExitWithStatus(0);
-		JUnit4JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
+		int statusCode = catchSystemExit(() -> JUnit4JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
 						ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
 						ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
 						ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample",
 						ParserOptions.FLAG_testMethodNamesToRun, "test3:test2:copyOftest2"
 				}
-		);
+		));
+		assertEquals(0, statusCode);
 		final CoveredTestResultPerTestMethod load = CoveredTestResultPerTestMethodImpl.load();
 		System.out.println(load);
 
@@ -88,13 +89,13 @@ public class JUnit4JacocoRunnerCoveredResultPerTestMethodTest extends AbstractTe
             Using the api to compute the coverage on test cases
          */
 
-		exit.expectSystemExitWithStatus(0);
-		JUnit4JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
+		int statusCode = catchSystemExit(() -> JUnit4JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
 						ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
 						ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
 						ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample",
 				}
-		);
+		));
+		assertEquals(0, statusCode);
 		final CoveredTestResultPerTestMethod load = CoveredTestResultPerTestMethodImpl.load();
 
 		System.out.println(load);

--- a/src/test/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunnerCoveredResultPerTestMethodTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunnerCoveredResultPerTestMethodTest.java
@@ -7,6 +7,7 @@ import eu.stamp_project.testrunner.runner.ParserOptions;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -21,14 +22,14 @@ public class JUnit5JacocoRunnerCoveredResultPerTestMethodTest extends AbstractTe
             Using the api to compute the coverage on a test class
          */
 
-		exit.expectSystemExitWithStatus(0);
-		JUnit5JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
+		int statusCode = catchSystemExit(() -> JUnit5JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
 						ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
 						ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
 						ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "junit5.ParametrizedTest",
 						ParserOptions.FLAG_testMethodNamesToRun, "test"
 				}
-		);
+		));
+		assertEquals(0, statusCode);
 		final CoveredTestResultPerTestMethod load = CoveredTestResultPerTestMethodImpl.load();
 		System.out.println(load);
 		assertEquals(34, load.getCoverageResultsMap().get("test").getInstructionsCovered());
@@ -42,14 +43,14 @@ public class JUnit5JacocoRunnerCoveredResultPerTestMethodTest extends AbstractTe
             Using the api to compute the coverage on test cases
          */
 
-		exit.expectSystemExitWithStatus(0);
-		JUnit5JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
+		int statusCode = catchSystemExit(() -> JUnit5JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
 						ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
 						ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
 						ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "junit5.TestSuiteExample",
 						ParserOptions.FLAG_testMethodNamesToRun, "test3:test2"
 				}
-		);
+		));
+		assertEquals(0, statusCode);
 		final CoveredTestResultPerTestMethod load = CoveredTestResultPerTestMethodImpl.load();
 		System.out.println(load);
 
@@ -72,13 +73,13 @@ public class JUnit5JacocoRunnerCoveredResultPerTestMethodTest extends AbstractTe
             Using the api to compute the coverage on test cases
          */
 
-		exit.expectSystemExitWithStatus(0);
-		JUnit5JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
+		int statusCode = catchSystemExit(() -> JUnit5JacocoRunnerCoveredResultPerTestMethod.main(new String[]{
 						ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
 						ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
 						ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "junit5.TestSuiteExample",
 				}
-		);
+		));
+		assertEquals(0, statusCode);
 		final CoveredTestResultPerTestMethod load = CoveredTestResultPerTestMethodImpl.load();
 		System.out.println(load);
 		load.getCoverageResultsMap()

--- a/src/test/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunnerTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/runner/coverage/JUnit5JacocoRunnerTest.java
@@ -10,6 +10,7 @@ import eu.stamp_project.testrunner.utils.ConstantsHelper;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -27,13 +28,13 @@ public class JUnit5JacocoRunnerTest extends AbstractTest {
             Using the api to compute the coverage on a test class
          */
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit5JacocoRunner.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit5JacocoRunner.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "junit5.TestSuiteExample",
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final Coverage load = CoverageImpl.load();
         assertEquals(30, load.getInstructionsCovered());
         assertEquals(EntryPointTest.NUMBER_OF_INSTRUCTIONS, load.getInstructionsTotal());
@@ -57,14 +58,14 @@ public class JUnit5JacocoRunnerTest extends AbstractTest {
             Using the api to compute the coverage on test cases
          */
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit5JacocoRunner.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit5JacocoRunner.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "junit5.TestSuiteExample",
                         ParserOptions.FLAG_testMethodNamesToRun, "test8:test2"
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final Coverage load = CoverageImpl.load();
         assertEquals(23, load.getInstructionsCovered());
         assertEquals(EntryPointTest.NUMBER_OF_INSTRUCTIONS, load.getInstructionsTotal());
@@ -78,14 +79,14 @@ public class JUnit5JacocoRunnerTest extends AbstractTest {
             Using the api to compute the coverage on test cases
          */
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit5JacocoRunner.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit5JacocoRunner.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "junit5.ParametrizedTest",
                         ParserOptions.FLAG_testMethodNamesToRun, "test"
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final Coverage load = CoverageImpl.load();
         assertEquals(23, load.getInstructionsCovered());
         assertEquals(EntryPointTest.NUMBER_OF_INSTRUCTIONS, load.getInstructionsTotal());
@@ -104,14 +105,14 @@ public class JUnit5JacocoRunnerTest extends AbstractTest {
     @Test
     public void testMethodDetailedCoverageDetail() throws Exception {
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit5JacocoRunner.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit5JacocoRunner.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "junit5.TestSuiteExample",
                         ParserOptions.FLAG_coverage_detail, ParserOptions.CoverageTransformerDetail.METHOD_DETAIL.name(),
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final Coverage load = CoverageImpl.load();
         for (String expectedMethodDetailedExecutionPath : expectedMethodDetailedExecutionPaths) {
             assertTrue(load.getExecutionPath().contains(expectedMethodDetailedExecutionPath));

--- a/src/test/java/eu/stamp_project/testrunner/runner/coverage/JacocoRunnerPerTestMethodTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/runner/coverage/JacocoRunnerPerTestMethodTest.java
@@ -4,8 +4,8 @@ import eu.stamp_project.testrunner.AbstractTest;
 import eu.stamp_project.testrunner.listener.impl.CoveragePerTestMethodImpl;
 import eu.stamp_project.testrunner.runner.ParserOptions;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -22,14 +22,14 @@ public class JacocoRunnerPerTestMethodTest extends AbstractTest {
             Using the api to compute the coverage on a test class
          */
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit4JacocoRunnerPerTestMethod.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit4JacocoRunnerPerTestMethod.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.ParametrizedTest",
                         ParserOptions.FLAG_testMethodNamesToRun, "test"
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final CoveragePerTestMethodImpl load = CoveragePerTestMethodImpl.load();
         System.out.println(load);
         assertEquals(34, load.getCoverageResultsMap().get("example.ParametrizedTest#test").getInstructionsCovered());
@@ -43,14 +43,14 @@ public class JacocoRunnerPerTestMethodTest extends AbstractTest {
             Using the api to compute the coverage on test cases
          */
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit4JacocoRunnerPerTestMethod.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit4JacocoRunnerPerTestMethod.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample",
                         ParserOptions.FLAG_testMethodNamesToRun, "test3:test2:copyOftest2"
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final CoveragePerTestMethodImpl load = CoveragePerTestMethodImpl.load();
         System.out.println(load);
         assertEquals(23, load.getCoverageResultsMap().get("example.TestSuiteExample#test2").getInstructionsCovered());
@@ -68,13 +68,13 @@ public class JacocoRunnerPerTestMethodTest extends AbstractTest {
             Using the api to compute the coverage on test cases
          */
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit4JacocoRunnerPerTestMethod.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit4JacocoRunnerPerTestMethod.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample",
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final CoveragePerTestMethodImpl load = CoveragePerTestMethodImpl.load();
         System.out.println(load);
         load.getCoverageResultsMap()

--- a/src/test/java/eu/stamp_project/testrunner/runner/coverage/JacocoRunnerTest.java
+++ b/src/test/java/eu/stamp_project/testrunner/runner/coverage/JacocoRunnerTest.java
@@ -9,6 +9,7 @@ import eu.stamp_project.testrunner.runner.ParserOptions;
 import eu.stamp_project.testrunner.utils.ConstantsHelper;
 import org.junit.Test;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -25,13 +26,13 @@ public class JacocoRunnerTest extends AbstractTest {
             Using the api to compute the coverage on a test class
          */
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit4JacocoRunner.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit4JacocoRunner.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample"
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final Coverage load = CoverageImpl.load();
         assertEquals(30, load.getInstructionsCovered());
         assertEquals(EntryPointTest.NUMBER_OF_INSTRUCTIONS, load.getInstructionsTotal());
@@ -46,14 +47,14 @@ public class JacocoRunnerTest extends AbstractTest {
             Using the api to compute the coverage on test cases
          */
 
-        exit.expectSystemExitWithStatus(0);
-        JUnit4JacocoRunner.main(new String[]{
+        int statusCode = catchSystemExit(() -> JUnit4JacocoRunner.main(new String[]{
                         ParserOptions.FLAG_pathToCompiledClassesOfTheProject, SOURCE_PROJECT_CLASSES,
                         ParserOptions.FLAG_pathToCompiledTestClassesOfTheProject, TEST_PROJECT_CLASSES,
                         ParserOptions.FLAG_fullQualifiedNameOfTestClassToRun, "example.TestSuiteExample",
                         ParserOptions.FLAG_testMethodNamesToRun, "test8:test2"
                 }
-        );
+        ));
+        assertEquals(0, statusCode);
         final Coverage load = CoverageImpl.load();
         assertEquals(23, load.getInstructionsCovered());
         assertEquals(EntryPointTest.NUMBER_OF_INSTRUCTIONS, load.getInstructionsTotal());

--- a/src/test/resources/test-projects/pom.xml
+++ b/src/test/resources/test-projects/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>3.4</version>
+            <version>4.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
flacoco is facing some issues when running test-runner on Java 18 (17 and below is working fine).

This PR adds several versions of the JDK to the CI workflow.

It also updates the distributions, since `adopt` has been deprecated and replaced by `temurin`, and some auxiliary actions.