### PR TITLE
chore: bump failing action (wait-on-check-action) to latest version (1.3.4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Wait for tests to pass
-        uses: lewagon/wait-on-check-action@v1.1.1
+        uses: lewagon/wait-on-check-action@v1.3.4
         with:
           ref: ${{ github.ref }}
           # Must be same as this job's name


### PR DESCRIPTION
@monperrus could you merge? trying to fix the CD script