### PR TITLE
save Throwable as Java object for each failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,13 @@
             <version>1.2.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>4.3</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -190,13 +190,6 @@
             <version>1.2.1</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>4.3</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/src/main/java/eu/stamp_project/testrunner/runner/Failure.java
+++ b/src/main/java/eu/stamp_project/testrunner/runner/Failure.java
@@ -20,7 +20,7 @@ public class Failure implements Serializable {
     public final String fullQualifiedNameOfException;
     public final String messageOfFailure;
     public final String stackTrace;
-    public Throwable throwable; // Throwable is not present if Failure is read from surefire report
+    public SerializableThrowable throwable; // Throwable is not present if Failure is read from surefire report
 
     public Failure(String testCaseName, String testClassName, Throwable exception) {
         this.testCaseName = testCaseName;
@@ -31,7 +31,7 @@ public class Failure implements Serializable {
         PrintWriter pw = new PrintWriter(sw);
         exception.printStackTrace(pw);
         this.stackTrace = sw.toString(); // stack trace as a string
-        this.throwable = exception;
+        this.throwable = new SerializableThrowable(exception);
     }
 
     public Failure(String testCaseName, String testClassName, String fullQualifiedNameOfException, String messageOfFailure, String stackTrace) {
@@ -68,4 +68,21 @@ public class Failure implements Serializable {
         result = 31 * result + (messageOfFailure != null ? messageOfFailure.hashCode() : 0);
         return result;
     }
+
+
+    public static class SerializableThrowable implements Serializable {
+
+        private static final long serialVersionUID = 2988580623727952827L;
+
+        public final String className;
+        public final String message;
+        public final StackTraceElement[] stackTrace;
+
+        public SerializableThrowable(Throwable throwable) {
+            this.className = throwable.getClass().getName();
+            this.message = throwable.getMessage();
+            this.stackTrace = throwable.getStackTrace();
+        }
+    }
+
 }

--- a/src/main/java/eu/stamp_project/testrunner/runner/Failure.java
+++ b/src/main/java/eu/stamp_project/testrunner/runner/Failure.java
@@ -3,6 +3,7 @@ package eu.stamp_project.testrunner.runner;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
+import java.util.Optional;
 
 /**
  * This class contains the result of failing test method.
@@ -13,11 +14,14 @@ import java.io.StringWriter;
  */
 public class Failure implements Serializable {
 
+    private final static long serialVersionUID = 4319480863941757524L;
+
     public final String testCaseName;
     public final String testClassName;
     public final String fullQualifiedNameOfException;
     public final String messageOfFailure;
     public final String stackTrace;
+    public final Optional<Throwable> throwable; // Throwable is not present if Failure is read from surefire report
 
     public Failure(String testCaseName, String testClassName, Throwable exception) {
         this.testCaseName = testCaseName;
@@ -28,6 +32,7 @@ public class Failure implements Serializable {
         PrintWriter pw = new PrintWriter(sw);
         exception.printStackTrace(pw);
         this.stackTrace = sw.toString(); // stack trace as a string
+        this.throwable = Optional.of(exception);
     }
 
     public Failure(String testCaseName, String testClassName, String fullQualifiedNameOfException, String messageOfFailure, String stackTrace) {
@@ -36,6 +41,7 @@ public class Failure implements Serializable {
         this.messageOfFailure = messageOfFailure;
         this.testClassName = testClassName;
         this.stackTrace = stackTrace;
+        this.throwable = Optional.empty();
     }
 
     @Override

--- a/src/main/java/eu/stamp_project/testrunner/runner/Failure.java
+++ b/src/main/java/eu/stamp_project/testrunner/runner/Failure.java
@@ -3,7 +3,6 @@ package eu.stamp_project.testrunner.runner;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
-import java.util.Optional;
 
 /**
  * This class contains the result of failing test method.
@@ -21,7 +20,7 @@ public class Failure implements Serializable {
     public final String fullQualifiedNameOfException;
     public final String messageOfFailure;
     public final String stackTrace;
-    public final Optional<Throwable> throwable; // Throwable is not present if Failure is read from surefire report
+    public Throwable throwable; // Throwable is not present if Failure is read from surefire report
 
     public Failure(String testCaseName, String testClassName, Throwable exception) {
         this.testCaseName = testCaseName;
@@ -32,7 +31,7 @@ public class Failure implements Serializable {
         PrintWriter pw = new PrintWriter(sw);
         exception.printStackTrace(pw);
         this.stackTrace = sw.toString(); // stack trace as a string
-        this.throwable = Optional.of(exception);
+        this.throwable = exception;
     }
 
     public Failure(String testCaseName, String testClassName, String fullQualifiedNameOfException, String messageOfFailure, String stackTrace) {
@@ -41,7 +40,6 @@ public class Failure implements Serializable {
         this.messageOfFailure = messageOfFailure;
         this.testClassName = testClassName;
         this.stackTrace = stackTrace;
-        this.throwable = Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
Hi,
the `Throwable` which is causing the test to fail is saved as an object. This allows for easier and more robust analysis and classification of the failures later.

Example:
```
TestResult result = EntryPoint.runTests(classpath, "org.example.TestMain");
Set<Failure> failures = result.getFailingTests();
for (Failure failure : failures) {
    if (failure.throwable instanceof AssertionError) {
        // handle failed assertions --> test failures
    } else if (failure.throwable instanceof RuntimeException) {
        //handle Runtime errors --> test errors
    }
}